### PR TITLE
Fn-fixes

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -87,10 +87,19 @@ const merge = (pair) => {
     const filledElems = template.elements.map((elem) => {
       if (elem.path === null) return elem
       if (elem.data !== null) return elem
+
+      // get data from wallet when given a path
       if (elem.path !== null) {
+        var data = get(wallet, elem.path)
+
+        // capitalize planet/galaxy/star class tier
+        if (elem.path === 'meta.tier') {
+          data = data.charAt(0).toUpperCase() + data.substring(1)
+        }
+
         return {
           ...elem,
-          data: get(wallet, elem.path),
+          data: data,
         }
       }
     })
@@ -115,6 +124,9 @@ const generatePng = (canvas, pair, debug, output) => {
     ctx.fillStyle = '#FFF'
     ctx.fillRect(0, 0, canvas.width, canvas.height)
 
+    page.classOf =
+      page.classOf.charAt(0).toUpperCase() + page.classOf.substring(1)
+    // console.log(page.classOf)
     page.elements.forEach((elem) => {
       try {
         draw[elem.draw](ctx, elem)
@@ -238,6 +250,7 @@ class PaperRenderer extends Component {
 
     // For each pair of wallet + templates, descend into the pages of each template, and again to each element of each template. Using the 'draw' property, call the function with a matching name to draw the data to the canvas. Do this for each element of each page, retrieve the image data from the canvas context and then clear the canvas before starting a new page.
     const trios = filledPairs.map((pair) => {
+      // console.log(pair)
       return generatePng(this.canvas, pair, this.props.debug, this.props.output)
     })
 

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -34,7 +34,7 @@ const extendWallet = async (wallet) => {
 
   // add the ship's azimuth url
   wallet.meta.azimuth = {
-    url: `${wallet.meta.patp}.azimuth.network`,
+    url: `${wallet.meta.patp.replace('~', '')}.azimuth.network`,
   }
 
   // get the renderer lib name and version number

--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -50,7 +50,7 @@ const extendWallet = async (wallet) => {
 
   // Add the date created with formatting
   const date = new Date()
-  wallet.meta.dateCreated = `${date.getDay()}/${date.getMonth()}/${date
+  wallet.meta.dateCreated = `${date.getDate()}/${date.getMonth()}/${date
     .getUTCFullYear()
     .toString()
     .slice(-2)}`

--- a/lib/src/templates.json
+++ b/lib/src/templates.json
@@ -101,8 +101,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 328,
           "width": 9.79134824774519e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -141,8 +141,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 328,
           "width": 9.79134824774519e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -181,8 +181,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 328,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -209,7 +209,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -230,8 +230,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.000001119011244554713,
           "height": 32,
           "strokeColor": "rgba(255,255,255,1)",
@@ -249,7 +249,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -270,8 +270,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(255,255,255,1)",
@@ -280,8 +280,8 @@
         {
           "type": "text",
           "draw": "wrappedText",
-          "path": null,
-          "data": ".~dottem-migmeb-ridlur-ropdyl",
+          "path": "ticket",
+          "data": null,
           "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 500,
@@ -314,7 +314,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(255,255,255,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 272
@@ -330,7 +330,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 294.5,
+          "y": 292,
           "fontColor": "rgba(255,255,255,1)"
         },
         {
@@ -394,7 +394,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -506,7 +506,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -520,7 +520,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -575,20 +575,6 @@
           "type": "text",
           "draw": "wrappedText",
           "path": null,
-          "data": "Very Secret",
-          "fontFamily": "Inter",
-          "fontSize": 18,
-          "fontWeight": 400,
-          "fontColor": "rgba(127,127,127,1)",
-          "maxWidth": 102,
-          "lineHeightPx": 18,
-          "x": 414,
-          "y": 32
-        },
-        {
-          "type": "text",
-          "draw": "wrappedText",
-          "path": null,
           "data": "If you lose this master ticket, you will have no way to recover this wallet or it’s proxies.",
           "fontFamily": "Inter",
           "fontSize": 12,
@@ -598,6 +584,20 @@
           "lineHeightPx": 16,
           "x": 96,
           "y": 620
+        },
+        {
+          "type": "text",
+          "draw": "wrappedText",
+          "path": null,
+          "data": "Secret",
+          "fontFamily": "Inter",
+          "fontSize": 18,
+          "fontWeight": 400,
+          "fontColor": "rgba(127,127,127,1)",
+          "maxWidth": 58,
+          "lineHeightPx": 18,
+          "x": 458,
+          "y": 32
         }
       ]
     },
@@ -699,8 +699,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 328,
           "width": 9.79134824774519e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -739,8 +739,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 328,
           "width": 9.79134824774519e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -779,8 +779,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 328,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -807,7 +807,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -828,8 +828,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.000001119011244554713,
           "height": 32,
           "strokeColor": "rgba(255,255,255,1)",
@@ -847,7 +847,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -868,8 +868,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(255,255,255,1)",
@@ -878,8 +878,8 @@
         {
           "type": "text",
           "draw": "wrappedText",
-          "path": null,
-          "data": ".~dottem-migmeb-ridlur-ropdyl",
+          "path": "ticket",
+          "data": null,
           "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 500,
@@ -912,7 +912,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(255,255,255,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 272
@@ -928,7 +928,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 294.5,
+          "y": 292,
           "fontColor": "rgba(255,255,255,1)"
         },
         {
@@ -992,7 +992,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -1104,7 +1104,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -1118,7 +1118,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -1271,7 +1271,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -1292,8 +1292,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(255,255,255,1)",
@@ -1311,7 +1311,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -1332,8 +1332,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(255,255,255,1)",
@@ -1376,7 +1376,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(255,255,255,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 208
@@ -1392,7 +1392,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 230.5,
+          "y": 228,
           "fontColor": "rgba(255,255,255,1)"
         },
         {
@@ -1456,8 +1456,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 264,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -1496,8 +1496,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 264,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -1536,8 +1536,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 264,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -1576,7 +1576,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -1631,7 +1631,7 @@
           "type": "text",
           "draw": "wrappedText",
           "path": null,
-          "data": "This is a secret document (cryptographic property). If someone else obtains this information, they may perform unauthorized actions on your behalf.  Please store this document and/or information in a private, secure place you won’t forget.",
+          "data": "This is a high value, secret document (cryptographic property).  If someone else obtains this information, they may perform unauthorized actions on your behalf. Please securely print and/or lock this document in a private, trusted place you won’t forget.",
           "fontFamily": "Inter",
           "fontSize": 12,
           "fontWeight": 400,
@@ -1645,7 +1645,7 @@
           "type": "text",
           "draw": "wrappedText",
           "path": null,
-          "data": "If you lose this seed, you can regenerate it with your master ticket.",
+          "data": "If you lose this shard, you can access your wallet with the other two shards.",
           "fontFamily": "Inter",
           "fontSize": 12,
           "fontWeight": 400,
@@ -1667,7 +1667,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 608
+          "y": 616
         },
         {
           "type": "text",
@@ -1681,7 +1681,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 632
+          "y": 640
         },
         {
           "type": "text",
@@ -1695,35 +1695,35 @@
           "maxWidth": 154,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 656
+          "y": 664
         },
         {
           "type": "text",
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
           "maxWidth": 252,
           "lineHeightPx": 16,
           "x": 270,
-          "y": 676
+          "y": 684
         },
         {
           "type": "text",
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
           "maxWidth": 268,
           "lineHeightPx": 16,
           "x": 270,
-          "y": 656
+          "y": 664
         },
         {
           "type": "text",
@@ -1737,7 +1737,7 @@
           "maxWidth": 12,
           "lineHeightPx": 16,
           "x": 258,
-          "y": 656
+          "y": 664
         },
         {
           "type": "text",
@@ -1751,7 +1751,7 @@
           "maxWidth": 12,
           "lineHeightPx": 16,
           "x": 258,
-          "y": 676
+          "y": 684
         },
         {
           "type": "text",
@@ -1765,7 +1765,7 @@
           "maxWidth": 154,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 676
+          "y": 684
         }
       ]
     },
@@ -1841,7 +1841,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -1862,8 +1862,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(255,255,255,1)",
@@ -1881,7 +1881,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -1902,8 +1902,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(255,255,255,1)",
@@ -1946,7 +1946,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(255,255,255,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 208
@@ -1962,7 +1962,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 230.5,
+          "y": 228,
           "fontColor": "rgba(255,255,255,1)"
         },
         {
@@ -2026,8 +2026,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 264,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -2066,8 +2066,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 264,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -2106,8 +2106,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 264,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -2146,7 +2146,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -2201,7 +2201,7 @@
           "type": "text",
           "draw": "wrappedText",
           "path": null,
-          "data": "This is a secret document (cryptographic property). If someone else obtains this information, they may perform unauthorized actions on your behalf.  Please store this document and/or information in a private, secure place you won’t forget.",
+          "data": "This is a high value, secret document (cryptographic property).  If someone else obtains this information, they may perform unauthorized actions on your behalf. Please securely print and/or lock this document in a private, trusted place you won’t forget.",
           "fontFamily": "Inter",
           "fontSize": 12,
           "fontWeight": 400,
@@ -2215,7 +2215,7 @@
           "type": "text",
           "draw": "wrappedText",
           "path": null,
-          "data": "If you lose this seed, you can regenerate it with your master ticket.",
+          "data": "If you lose this shard, you can access your wallet with the other two shards.",
           "fontFamily": "Inter",
           "fontSize": 12,
           "fontWeight": 400,
@@ -2237,7 +2237,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 608
+          "y": 616
         },
         {
           "type": "text",
@@ -2251,7 +2251,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 632
+          "y": 640
         },
         {
           "type": "text",
@@ -2265,35 +2265,35 @@
           "maxWidth": 154,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 656
+          "y": 664
         },
         {
           "type": "text",
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
           "maxWidth": 252,
           "lineHeightPx": 16,
           "x": 270,
-          "y": 676
+          "y": 684
         },
         {
           "type": "text",
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
           "maxWidth": 268,
           "lineHeightPx": 16,
           "x": 270,
-          "y": 656
+          "y": 664
         },
         {
           "type": "text",
@@ -2307,7 +2307,7 @@
           "maxWidth": 12,
           "lineHeightPx": 16,
           "x": 258,
-          "y": 656
+          "y": 664
         },
         {
           "type": "text",
@@ -2321,7 +2321,7 @@
           "maxWidth": 12,
           "lineHeightPx": 16,
           "x": 258,
-          "y": 676
+          "y": 684
         },
         {
           "type": "text",
@@ -2335,7 +2335,7 @@
           "maxWidth": 154,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 676
+          "y": 684
         }
       ]
     },
@@ -2411,7 +2411,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -2432,8 +2432,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(255,255,255,1)",
@@ -2451,7 +2451,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -2472,8 +2472,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(255,255,255,1)",
@@ -2516,7 +2516,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(255,255,255,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 208
@@ -2532,7 +2532,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 230.5,
+          "y": 228,
           "fontColor": "rgba(255,255,255,1)"
         },
         {
@@ -2596,8 +2596,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 264,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -2636,8 +2636,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 264,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -2676,8 +2676,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 264,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(255,255,255,1)",
@@ -2716,7 +2716,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -2771,7 +2771,7 @@
           "type": "text",
           "draw": "wrappedText",
           "path": null,
-          "data": "This is a secret document (cryptographic property). If someone else obtains this information, they may perform unauthorized actions on your behalf.  Please store this document and/or information in a private, secure place you won’t forget.",
+          "data": "This is a high value, secret document (cryptographic property).  If someone else obtains this information, they may perform unauthorized actions on your behalf. Please securely print and/or lock this document in a private, trusted place you won’t forget.",
           "fontFamily": "Inter",
           "fontSize": 12,
           "fontWeight": 400,
@@ -2785,7 +2785,7 @@
           "type": "text",
           "draw": "wrappedText",
           "path": null,
-          "data": "If you lose this seed, you can regenerate it with your master ticket.",
+          "data": "If you lose this shard, you can access your wallet with the other two shards.",
           "fontFamily": "Inter",
           "fontSize": 12,
           "fontWeight": 400,
@@ -2807,7 +2807,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 608
+          "y": 616
         },
         {
           "type": "text",
@@ -2821,7 +2821,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 632
+          "y": 640
         },
         {
           "type": "text",
@@ -2835,35 +2835,35 @@
           "maxWidth": 154,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 656
+          "y": 664
         },
         {
           "type": "text",
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
           "maxWidth": 252,
           "lineHeightPx": 16,
           "x": 270,
-          "y": 676
+          "y": 684
         },
         {
           "type": "text",
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
           "maxWidth": 268,
           "lineHeightPx": 16,
           "x": 270,
-          "y": 656
+          "y": 664
         },
         {
           "type": "text",
@@ -2877,7 +2877,7 @@
           "maxWidth": 12,
           "lineHeightPx": 16,
           "x": 258,
-          "y": 656
+          "y": 664
         },
         {
           "type": "text",
@@ -2891,7 +2891,7 @@
           "maxWidth": 12,
           "lineHeightPx": 16,
           "x": 258,
-          "y": 676
+          "y": 684
         },
         {
           "type": "text",
@@ -2905,7 +2905,7 @@
           "maxWidth": 154,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 676
+          "y": 684
         }
       ]
     },
@@ -2993,8 +2993,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 280,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -3033,8 +3033,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 280,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -3073,8 +3073,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 280,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -3101,7 +3101,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -3122,8 +3122,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -3141,7 +3141,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -3162,8 +3162,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -3178,7 +3178,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 224
@@ -3194,7 +3194,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 246.5,
+          "y": 244,
           "fontColor": "rgba(0,0,0,1)"
         },
         {
@@ -3272,7 +3272,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -3398,7 +3398,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -3412,7 +3412,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -3563,8 +3563,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 280,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -3603,8 +3603,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 280,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -3643,8 +3643,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 280,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -3671,7 +3671,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -3692,8 +3692,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -3711,7 +3711,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -3732,8 +3732,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -3748,7 +3748,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 224
@@ -3764,7 +3764,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 246.5,
+          "y": 244,
           "fontColor": "rgba(0,0,0,1)"
         },
         {
@@ -3842,7 +3842,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -3968,7 +3968,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -3982,7 +3982,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -4133,8 +4133,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 280,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -4173,8 +4173,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 280,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -4213,8 +4213,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 280,
           "width": 9.791349384613568e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -4241,7 +4241,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -4262,8 +4262,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -4281,7 +4281,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -4302,8 +4302,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -4318,7 +4318,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 224
@@ -4334,7 +4334,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 246.5,
+          "y": 244,
           "fontColor": "rgba(0,0,0,1)"
         },
         {
@@ -4412,7 +4412,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -4538,7 +4538,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -4552,7 +4552,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -4677,7 +4677,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -4698,8 +4698,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -4717,7 +4717,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -4738,8 +4738,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -4820,8 +4820,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -4860,8 +4860,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -4900,8 +4900,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -4916,7 +4916,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 224
@@ -4932,7 +4932,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 246.5,
+          "y": 244,
           "fontColor": "rgba(0,0,0,1)"
         },
         {
@@ -4996,7 +4996,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -5108,7 +5108,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -5122,7 +5122,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -5301,8 +5301,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -5341,8 +5341,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -5381,8 +5381,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -5409,7 +5409,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -5430,8 +5430,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -5449,7 +5449,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -5470,8 +5470,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -5486,7 +5486,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 224
@@ -5502,7 +5502,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 246.5,
+          "y": 244,
           "fontColor": "rgba(0,0,0,1)"
         },
         {
@@ -5566,7 +5566,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -5678,7 +5678,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -5692,7 +5692,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -5871,8 +5871,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -5911,8 +5911,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -5951,8 +5951,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -5979,7 +5979,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -6000,8 +6000,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -6019,7 +6019,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -6040,8 +6040,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -6056,7 +6056,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 224
@@ -6072,7 +6072,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 246.5,
+          "y": 244,
           "fontColor": "rgba(0,0,0,1)"
         },
         {
@@ -6136,7 +6136,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -6248,7 +6248,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -6262,7 +6262,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -6427,8 +6427,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -6467,8 +6467,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -6507,8 +6507,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -6535,7 +6535,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -6556,8 +6556,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -6575,7 +6575,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -6596,8 +6596,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -6612,7 +6612,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 224
@@ -6628,7 +6628,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 246.5,
+          "y": 244,
           "fontColor": "rgba(0,0,0,1)"
         },
         {
@@ -6692,7 +6692,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -6804,7 +6804,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -6818,7 +6818,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -7011,8 +7011,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -7051,8 +7051,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -7091,8 +7091,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -7119,7 +7119,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -7140,8 +7140,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -7159,7 +7159,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -7180,8 +7180,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -7191,12 +7191,12 @@
           "type": "text",
           "draw": "wrappedText",
           "path": null,
-          "data": "Management Address",
+          "data": "Voting Address",
           "fontFamily": "Inter",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 224
@@ -7204,7 +7204,7 @@
         {
           "type": "ethereumAddress",
           "draw": "ethereumAddress",
-          "path": "management.keys.address",
+          "path": "voting.keys.address",
           "data": null,
           "fontWeight": 500,
           "fontFamily": "Source Code Pro",
@@ -7212,7 +7212,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 246.5,
+          "y": 244,
           "fontColor": "rgba(0,0,0,1)"
         },
         {
@@ -7276,7 +7276,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -7388,7 +7388,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -7402,7 +7402,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -7513,7 +7513,7 @@
           "maxWidth": 168,
           "lineHeightPx": 16,
           "x": 206,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -7534,8 +7534,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -7553,7 +7553,7 @@
           "maxWidth": 135,
           "lineHeightPx": 16,
           "x": 426,
-          "y": 112
+          "y": 116
         },
         {
           "type": "text",
@@ -7574,8 +7574,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 96,
           "width": 0.0000011190113582415506,
           "height": 32,
           "strokeColor": "rgba(0,0,0,1)",
@@ -7656,8 +7656,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 186,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -7696,8 +7696,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 296,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -7736,8 +7736,8 @@
           "draw": "line",
           "path": null,
           "data": null,
-          "x": null,
-          "y": null,
+          "x": 406,
+          "y": 280,
           "width": 9.791347110876814e-7,
           "height": 24,
           "strokeColor": "rgba(0,0,0,1)",
@@ -7752,7 +7752,7 @@
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
-          "maxWidth": 352.31787109375,
+          "maxWidth": 352,
           "lineHeightPx": 16,
           "x": 96,
           "y": 224
@@ -7768,7 +7768,7 @@
           "maxWidth": 420,
           "lineHeightPx": 16,
           "x": 96,
-          "y": 246.5,
+          "y": 244,
           "fontColor": "rgba(0,0,0,1)"
         },
         {
@@ -7832,7 +7832,7 @@
           "draw": "wrappedText",
           "path": "meta.azimuth.url",
           "data": null,
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -7944,7 +7944,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "support@urbit.org",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",
@@ -7958,7 +7958,7 @@
           "draw": "wrappedText",
           "path": null,
           "data": "urbit.org/docs",
-          "fontFamily": "Inter",
+          "fontFamily": "Source Code Pro",
           "fontSize": 12,
           "fontWeight": 400,
           "fontColor": "rgba(0,0,0,1)",

--- a/tools/component.js
+++ b/tools/component.js
@@ -188,6 +188,8 @@ const ethereumAddress = (child, frame) => {
 // }
 
 const rect = (child, frame) => {
+  // if(frame.originX === undefined)
+  //   console.log(frame)
   return {
     type: 'rect',
     draw: 'rect',
@@ -231,7 +233,7 @@ const components = {
   img: (child, frame) => img(child, frame),
   // wrapAddrSplitFour: (child, frame) => wrapAddrSplitFour(child, frame),
   ethereumAddress: (child, frame) => ethereumAddress(child, frame),
-  line: (child, tframe) => line(child, frame),
+  line: (child, frame) => line(child, frame),
 }
 
 const getComponent = (child, frame) => {


### PR DESCRIPTION
#129 : render vertical lines. remove the "t" typo from `line: (child, tframe) => line(child, frame)`

#130 : fix master ticket data.  remove all instances of deprecated patq component in figma 

#135 : fix date (use `getDate()` to get 0-31 date of month instead of `getDay()` which gets 0-6 day of week)

#136 : remove ~ from bridge url 

#140 : uppercase class name 