### PR TITLE
prevent crashing if toDataURL is disabled

### DIFF
--- a/lib/src/index.js
+++ b/lib/src/index.js
@@ -225,6 +225,12 @@ class PaperRenderer extends Component {
   async componentDidMount() {
     this.canvas = initCanvas(this.canvasRef.current, CANVAS_SIZE, 4)
 
+    // Prevent crashing if canvas.toDataURL is disabled for
+    // tracking reaons
+    if (canvas.toDataURL('image/png').length === 0) {
+      return
+    }
+
     // An array of extendWallet promises
     const _extendedWallets = this.props.wallets.map((wallet) => {
       return extendWallet(clone(wallet))

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "gulp-cssnano": "^2.1.2",
     "gulp-gzip": "^1.4.2",
     "gulp-header": "^2.0.7",
-    "gulp-inline-fonts": "github:urbit/gulp-inline-fonts",
     "gulp-minify": "^3.1.0",
     "gulp-rename": "^1.4.0",
     "gulp-run": "^1.7.1",


### PR DESCRIPTION
Brave always returns the empty string from toDataURL if anti-fingerprinting settings are enabled. This causes atob to throw an error (see: urbit/bridge#399). Changed so we simply don't generate the images, which then punts checking up to the caller, which imo is ideal.

cc: @g-a-v-i-n 